### PR TITLE
cli/command: ps: only check format-template once

### DIFF
--- a/cli/command/formatter/container.go
+++ b/cli/command/formatter/container.go
@@ -27,7 +27,7 @@ const (
 // NewContainerFormat returns a Format for rendering using a Context
 func NewContainerFormat(source string, quiet bool, size bool) Format {
 	switch source {
-	case TableFormatKey:
+	case TableFormatKey, "": // table formatting is the default if none is set.
 		if quiet {
 			return DefaultQuietFormat
 		}
@@ -54,8 +54,9 @@ ports: {{- pad .Ports 1 0}}
 			format += `size: {{.Size}}\n`
 		}
 		return Format(format)
+	default: // custom format
+		return Format(source)
 	}
-	return Format(source)
 }
 
 // ContainerWrite renders the context for a list of containers


### PR DESCRIPTION
- do an early check if a custom format is specified either through the
  command-line, or through the cli's configuration, before adjusting
  the options (to add "size" if needed).
- if no format is set after this, set the default (formatter.TableFormatKey)
- also removes a redundant `options.Size = opts.size` line, as this value is
  already copied at the start of buildContainerListOptions()


