### PR TITLE
use trimQuotes() for trimming quotes

### DIFF
--- a/opts/envfile_test.go
+++ b/opts/envfile_test.go
@@ -3,9 +3,11 @@ package opts
 import (
 	"bufio"
 	"os"
-	"reflect"
 	"strings"
 	"testing"
+
+	"gotest.tools/v3/assert"
+	is "gotest.tools/v3/assert/cmp"
 )
 
 func tmpFileWithContent(t *testing.T, content string) string {
@@ -37,6 +39,13 @@ with.dots=working
 and_underscore=working too
 single_quotes='quotes working'
 double_quotes="quotes working"
+mixed_quotes1='quotes working"
+mixed_quotes2="quotes working'
+nested_quotes1="'quotes working'"
+nested_quotes2='"quotes working"'
+whitespace1=    string with whitespace    
+whitespace2='    string with single-quoted whitespace    '
+whitespace3="    string with double-quoted whitespace    "
 `
 	// Adding a newline + a line with pure whitespace.
 	// This is being done like this instead of the block above
@@ -59,10 +68,16 @@ double_quotes="quotes working"
 		"and_underscore=working too",
 		"single_quotes=quotes working",
 		"double_quotes=quotes working",
+		`mixed_quotes1='quotes working"`,
+		`mixed_quotes2="quotes working'`,
+		`nested_quotes1='quotes working'`,
+		`nested_quotes2="quotes working"`,
+		`whitespace1=    string with whitespace    `,
+		`whitespace2=    string with single-quoted whitespace    `,
+		`whitespace3=    string with double-quoted whitespace    `,
 	}
-
-	if !reflect.DeepEqual(lines, expectedLines) {
-		t.Fatal("lines not equal to expectedLines")
+	for i, expected := range expectedLines {
+		assert.Check(t, is.Equal(lines[i], expected))
 	}
 }
 

--- a/opts/file.go
+++ b/opts/file.go
@@ -10,10 +10,7 @@ import (
 	"unicode/utf8"
 )
 
-const (
-	whiteSpaces = " \t"
-	quotes      = "'\""
-)
+const whiteSpaces = " \t"
 
 // ErrBadKey typed error for bad environment variable
 type ErrBadKey struct {
@@ -62,11 +59,7 @@ func parseKeyValueFile(filename string, emptyFn func(string) (string, bool)) ([]
 
 			if len(data) > 1 {
 				// pass the value through, trimming leading and trailing quotes
-				value := data[1]
-				value = strings.TrimLeft(value, quotes)
-				value = strings.TrimRight(value, quotes)
-
-				lines = append(lines, fmt.Sprintf("%s=%s", variable, value))
+				lines = append(lines, variable+"="+trimQuotes(data[1]))
 			} else {
 				var value string
 				var present bool


### PR DESCRIPTION
This makes sure that only the outer-most quotes are trimmed, and
that quotes are only trimmed if equal (start/end).

**- Description for the changelog**
<!--
Write a short (one line) summary that describes the changes in this
pull request for inclusion in the changelog:
-->


**- A picture of a cute animal (not mandatory but encouraged)**

